### PR TITLE
Ложная ошибка "Not enough permissions to publish your status"

### DIFF
--- a/extensions/status-to-vk.py
+++ b/extensions/status-to-vk.py
@@ -10,10 +10,12 @@ def statustovk_prs01(source, prs):
 	if source in Transport and prs.getType() in ("available", None):
 		user = Transport[source]
 		if user.settings.status_to_vk:
-			mask = user.vk.method("account.getAppPermissions") or 0
+			mask = user.vk.method("account.getAppPermissions") or None
 			status = prs.getStatus()
 			if not getattr(user, "last_status", None) or user.last_status != status:
-				if mask & 1024 == 1024:
+				if not mask:
+					logger.error("can't receive permission bitmask (jid: %s)" % source)
+				elif mask & 1024 == 1024:
 					if not status:
 						user.vk.method("status.set", {"text": ""})
 					else:


### PR DESCRIPTION
При запуске xmpp клиента от транспорта выдаётся множество ошибок "Недостаточно прав для публикации статуса на сайте. Пожалуйста, зарегистрируйтесь заново." при том, что на самом деле прав хватает. После того как клиент запустился перестают появляться эти ошибки. Мною был подготовлен небольшой патч. К сожалению он немного спорный. Всё упирается в строчку:
``` python
mask = user.vk.method("account.getAppPermissions") or 0
```
Я не смог придумать другой ситации при которой не возможно получить permission mask и следует считать её нулём, поэтому считаю что данный патч коректен. Но это не значит что таких ситуаций не бывает.