### PR TITLE
Fix bug: README files in extensions/ were treated as python modules

### DIFF
--- a/gateway.py
+++ b/gateway.py
@@ -892,7 +892,7 @@ def loadExtensions(dir):
 	Read and exec files located in dir
 	"""
 	for file in os.listdir(dir):
-		if not file.startswith("."):
+		if not file.startswith(".") and file.endswith(".py"):
 			execfile("%s/%s" % (dir, file), globals())
 
 


### PR DESCRIPTION
Fixes this error:

 5月 01 23:01:28 nuor systemd[1]: vk4xmpp.service: main process exited, code=exited, status=1/FAILURE
 5月 01 23:01:28 nuor systemd[1]: Unit vk4xmpp.service entered failed state.
 5月 01 23:01:39 nuor env[18940]: #-# Config loaded successfully.
 5月 01 23:01:39 nuor env[18940]: Traceback (most recent call last):
 5月 01 23:01:39 nuor env[18940]: File "gateway.py", line 1032, in <module>
 5月 01 23:01:39 nuor env[18940]: loadExtensions("extensions")
 5月 01 23:01:39 nuor env[18940]: File "gateway.py", line 896, in loadExtensions
 5月 01 23:01:39 nuor env[18940]: execfile("%s/%s" % (dir, file), globals())
 5月 01 23:01:39 nuor env[18940]: File "extensions/avatar_hash.README.md", line 2
 5月 01 23:01:39 nuor env[18940]: ====
 5月 01 23:01:39 nuor env[18940]: ^
 5月 01 23:01:39 nuor env[18940]: SyntaxError: invalid syntax
